### PR TITLE
Tear-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ will install `s3same` (from the master branch of the source of this repo) as a c
 
 ```
 $ s3same --help
-Usage: s3same [OPTIONS]
+Usage: s3same [OPTIONS] REPO
 
 Options:
-  --repo TEXT         The target repository  [required]
   --pro               Use Travis CI Pro
   --github TEXT       GitHub token
   --owner TEXT        GitHub owner
@@ -25,6 +24,7 @@ Options:
   --aws-key TEXT      AWS key
   --aws-secret TEXT   AWS secret
   --aws-profile TEXT  AWS profile
+  --nuke              Nuke the entire s3same setup on IAM
   --help              Show this message and exit.
 ```
 
@@ -39,7 +39,7 @@ If your AWS credentials are in the default profile, you can omit the `AWS_PROFIL
 
 With all the credentials in place, running
 ```
-$ s3same --repo some-repo-name --owner some-user --pro
+$ s3same some-repo-name --owner some-user --pro
 ```
 will create an AWS IAM user unique to the repo (`s3same_travis__some-user__some-repo-name`), add that user to the `s3same_travis` AWS IAM group (creating the group if it doesn't exist) to give it the necessary permissions (defined by the `s3same_travis` policy, which will be created if it doesn't exist), generate an AWS key and secret for that user, use the public key for the given repo on Travis CI to encrypt the key and secret, and print out the YAML snippet to use for artifact uploading credentials.
 

--- a/bin/s3same
+++ b/bin/s3same
@@ -10,7 +10,7 @@ if exists(env_path):
     load_dotenv(env_path)
 
 @click.command()
-@click.option('--repo', required=True, help='The target repository')
+@click.argument('repo', required=True)
 @click.option('--pro', is_flag=True, help='Use Travis CI Pro')
 @click.option('--github',
         'github_token',

--- a/bin/s3same
+++ b/bin/s3same
@@ -1,13 +1,39 @@
 #!/usr/bin/env python
 
 from os.path import abspath, expanduser, exists
+from time import sleep
+from itertools import cycle
+from datetime import datetime, timedelta
 import click
 from dotenv import load_dotenv
-from s3same import artifact_yaml
+from s3same import artifact_yaml, iam_nuke
 
 env_path = abspath(expanduser('~/.s3same'))
 if exists(env_path):
     load_dotenv(env_path)
+
+def nuke(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    if not click.confirm('Are you sure you want to nuke the whole s3same setup from IAM?'):
+        click.echo('Aborted.')
+        ctx.exit()
+    click.secho(
+            '\nDoing this will make any s3same-generated credentials invalid.\nThere is NO WAY to undo this.\n',
+            bold=True)
+    click.echo('Take a moment to think it over…   ', nl=False)
+    spinner = cycle(['|', '/', '-', '\\'])
+    end_time = datetime.now() + timedelta(seconds=5)
+    while datetime.now() < end_time:
+        click.echo('\b{}'.format(next(spinner)), nl=False)
+        sleep(0.1)
+    click.echo('\x1b[2K\r', nl=False)  # Clear the "Take a moment…" spinner line.
+    if not click.confirm('You\'re really sure?'):
+        click.echo('Aborted.')
+        ctx.exit()
+    iam_nuke(**ctx.params)
+    click.echo('Nuked.')
+    ctx.exit()
 
 @click.command()
 @click.argument('repo', required=True)
@@ -25,16 +51,26 @@ if exists(env_path):
         help='S3 bucket for artifacts')
 @click.option('--aws-region',
         envvar='AWS_REGION',
+        is_eager=True,
         help='AWS region')
 @click.option('--aws-key',
         envvar='AWS_ACCESS_KEY_ID',
+        is_eager=True,
         help='AWS key')
 @click.option('--aws-secret',
         envvar='AWS_SECRET_ACCESS_KEY',
+        is_eager=True,
         help='AWS secret')
 @click.option('--aws-profile',
         envvar='AWS_PROFILE',
+        is_eager=True,
         help='AWS profile')
+@click.option('--nuke',
+        is_flag=True,
+        expose_value=False,
+        is_eager=True,
+        callback=nuke,
+        help='Nuke the entire s3same setup on IAM')
 def s3same(**kwargs):
     if 'github_token' not in kwargs:
         raise click.UsageError('You must specify a GitHub token.')

--- a/s3same/__init__.py
+++ b/s3same/__init__.py
@@ -3,9 +3,9 @@ import travispy
 import yaml
 
 from .travis import travis_encrypt as _travis_encrypt
-from .iam import credentials_for_new_user, IAMName
+from .iam import credentials_for_new_user, nuke_iam, IAMName
 
-__all__ = [ 'artifact_yaml', 'travis_encrypt', 'iam_credentials', ]
+__all__ = [ 'artifact_yaml', 'travis_encrypt', 'iam_credentials', 'iam_nuke', ]
 
 def artifact_yaml(
         repo, pro, github_token, github_owner, s3_bucket,
@@ -44,3 +44,12 @@ def iam_credentials(
             '{}__{}__{}'.format(IAMName, github_owner, repo),
             s3_bucket,
             )
+
+def iam_nuke(aws_region=None, aws_key=None, aws_secret=None, aws_profile=None):
+    iam = boto3.session.Session(
+            aws_access_key_id=aws_key,
+            aws_secret_access_key=aws_secret,
+            region_name=aws_region,
+            profile_name=aws_profile,
+            ).client('iam')
+    nuke_iam(iam)

--- a/s3same/__init__.py
+++ b/s3same/__init__.py
@@ -5,35 +5,42 @@ import yaml
 from .travis import travis_encrypt as _travis_encrypt
 from .iam import credentials_for_new_user, IAMName
 
-__all__ = [ 'artifact_yaml', ]
+__all__ = [ 'artifact_yaml', 'travis_encrypt', 'iam_credentials', ]
 
 def artifact_yaml(
         repo, pro, github_token, github_owner, s3_bucket,
         aws_region=None, aws_key=None, aws_secret=None, aws_profile=None):
+    credentials = iam_credentials(repo, github_owner, s3_bucket, aws_region, aws_key, aws_secret, aws_profile)
+    enc_key, enc_secret = travis_encrypt(
+            repo, pro, github_token, github_owner,
+            (credentials['AccessKeyId'], credentials['SecretAccessKey'],),
+            )
+    return yaml.safe_dump({
+        'key': { 'secure': enc_key, },
+        'secret': { 'secure': enc_secret, },
+        },
+        default_flow_style=False,
+        )
+
+def travis_encrypt(repo, pro, github_token, github_owner, strings):
     travis = travispy.TravisPy.github_auth(
             github_token,
             uri=travispy.travispy.PRIVATE if pro else travispy.travispy.PUBLIC,
             )
+    repo_slug = '{}/{}'.format(github_owner, repo)
+    return (_travis_encrypt(travis, repo_slug, string) for string in strings)
+
+def iam_credentials(
+        repo, github_owner, s3_bucket,
+        aws_region=None, aws_key=None, aws_secret=None, aws_profile=None):
     iam = boto3.session.Session(
             aws_access_key_id=aws_key,
             aws_secret_access_key=aws_secret,
             region_name=aws_region,
             profile_name=aws_profile,
             ).client('iam')
-    access_key = credentials_for_new_user(
+    return credentials_for_new_user(
             iam,
             '{}__{}__{}'.format(IAMName, github_owner, repo),
             s3_bucket,
             )
-    repo_slug = '{}/{}'.format(github_owner, repo)
-    return yaml.safe_dump({
-        'key': {
-            'secure': _travis_encrypt(travis, repo_slug, access_key['AccessKeyId']),
-            },
-        'secret': {
-            'secure': _travis_encrypt(travis, repo_slug, access_key['SecretAccessKey']),
-            },
-        },
-        default_flow_style=False,
-        allow_unicode=True,
-        )

--- a/s3same/iam.py
+++ b/s3same/iam.py
@@ -101,7 +101,7 @@ def _users_in_group(iam):
 def _keys_for_user(iam, username):
     return _all_pages(iam.list_access_keys, 'AccessKeyMetadata', UserName=username)
 
-def _delete_group(iam):
+def nuke_iam(iam):
     try:
         users = list(_users_in_group(iam))
     except ClientError as e:


### PR DESCRIPTION
- Take the repo as a positional argument instead of a flagged option.
- Added functions to remove IAM credentials, users, policy, and group.
- Exposed iam-credential-creation, travis-encryption, and iam-nuking at the library level.
- Expose the `--nuke` flag to completely nuke the IAM setup (with two confirmation prompts separated by a 5-second delay)

@projectweekend @WorkHorseIndustries @foresmac @adambain-vokal @Tuss4 @vhoof @scottferg @chillpop @brockboland Code review please?
