### PR TITLE
Replace proper ellipses with periods to prevent encoding error

### DIFF
--- a/bin/s3same
+++ b/bin/s3same
@@ -21,13 +21,13 @@ def nuke(ctx, param, value):
     click.secho(
             '\nDoing this will make any s3same-generated credentials invalid.\nThere is NO WAY to undo this.\n',
             bold=True)
-    click.echo('Take a moment to think it over…   ', nl=False)
+    click.echo('Take a moment to think it over...   ', nl=False)
     spinner = cycle(['|', '/', '-', '\\'])
     end_time = datetime.now() + timedelta(seconds=5)
     while datetime.now() < end_time:
         click.echo('\b{}'.format(next(spinner)), nl=False)
         sleep(0.1)
-    click.echo('\x1b[2K\r', nl=False)  # Clear the "Take a moment…" spinner line.
+    click.echo('\x1b[2K\r', nl=False)  # Clear the "Take a moment..." spinner line.
     if not click.confirm('You\'re really sure?'):
         click.echo('Aborted.')
         ctx.exit()

--- a/bin/s3same
+++ b/bin/s3same
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 from os.path import abspath, expanduser, exists
 from time import sleep
@@ -21,13 +22,13 @@ def nuke(ctx, param, value):
     click.secho(
             '\nDoing this will make any s3same-generated credentials invalid.\nThere is NO WAY to undo this.\n',
             bold=True)
-    click.echo('Take a moment to think it over...   ', nl=False)
+    click.echo('Take a moment to think it over…   ', nl=False)
     spinner = cycle(['|', '/', '-', '\\'])
     end_time = datetime.now() + timedelta(seconds=5)
     while datetime.now() < end_time:
         click.echo('\b{}'.format(next(spinner)), nl=False)
         sleep(0.1)
-    click.echo('\x1b[2K\r', nl=False)  # Clear the "Take a moment..." spinner line.
+    click.echo('\x1b[2K\r', nl=False)  # Clear the "Take a moment…" spinner line.
     if not click.confirm('You\'re really sure?'):
         click.echo('Aborted.')
         ctx.exit()


### PR DESCRIPTION
Fixes these errors:
- SyntaxError: Non-ASCII character '\xe2' in file /usr/local/bin/s3same on line 24, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
- SyntaxError: Non-ASCII character '\xe2' in file /usr/local/bin/s3same on line 30, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

I know we could change the encoding on the file but this seems way easier.

@vokal-isaac @vokal/systems 
