### PR TITLE
Encryption changed, new setup.py line for support for both Python versions, docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Vokal
+Copyright (c) 2018 Vokal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,55 +1,94 @@
 # s3same
+
 `s3same` ("sesame", like ["open sesame"](https://en.wikipedia.org/wiki/Open_Sesame_(phrase))) creates unique-per-repo AWS credentials for Travis CI artifact uploading to S3 and encrypts those credentials with the repo's public key.
 
 ## Prerequisities
-- You may need to install and configure AWS CLI prior.
+
+Make sure you have [`pip`](https://pip.pypa.io/en/stable/installing/) installed. `pip` is a package manager for Python packages. You can learn more by going to the [PyPI](https://pypi.org/) official website.
+
+A [`virtualenv`](https://virtualenv.pypa.io/en/latest/) environment is recommended since it keeps your Python projects organized by keeping installed packages in its own environment:
+
+To install globally with `pip`:
+
+```sh
+sudo pip install virtualenv
+```
+
+Create and activate a `virtualenv` environment:
+
+```sh
+$ virtualenv env
+$ source env/bin/activate
+(env) $
+```
+
+- When done using `s3same`, exit `virtualenv`:
+
+  ```sh
+  (env) $ deactivate
+  $
+  ```
+
+You may need to install and configure AWS CLI prior.
+  
 This is easily accomplished using [homebrew](https://brew.sh/).
 
 Running the command
+
 ```sh
 brew install awscli
 ```
+
 will install the latest release of awscli.
 
 Running the command
+
 ```sh
 aws configure
 ```
+
 will initiate configuration.
 
 It will prompt you for the following values:
+
 ```sh
 AWS Access Key ID [None]: YourKey
 AWS Secret Access Key [None]: YourKey
 Default region name [None]: us-west-2
 Default output format [None]: text
 ```
+
 **NOTE:** You may need the help of a Senior iOS dev or a member of the Systems team to generate an AWS Access Key ID and AWS Secret Access Key.
 
 - You may also need to install pip
 
 Run the command
+
 ```sh
 sudo easy_install pip
 ```
+
 to install.
 
 ## Installation
 
 Running the command
+
 ```sh
 sudo pip install s3same
 ```
+
 will install the latest stable release of `s3same` as a command in `/usr/local/bin`.
 
 Note, if you are having issues related to the file directory not being found, you may need to try appending the --no-binary option with the :all: value to the command
+
 ```sh
 sudo pip install --no-binary :all: s3same
 ```
 
 ## Usage
 
-```
+```sh
 $ s3same --help
 Usage: s3same [OPTIONS] REPO
 
@@ -67,18 +106,22 @@ Options:
 ```
 
 Let's assume you've got your AWS credentials in [`~/.aws/credentials`](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files).  Go to your GitHub settings and [create a personal access token](https://github.com/settings/tokens/new) for `s3same` (the token must have the `repo` permission).  Create `~/.s3same` with:
+
 ```
 GITHUB_TOKEN=put your token here
 S3_BUCKET=the bucket to which artifacts will be uploaded
 AWS_PROFILE=some profile
 AWS_REGION=your AWS region
 ```
+
 If your AWS credentials are in the default profile, you can omit the `AWS_PROFILE` line.
 
 With all the credentials in place, running
+
+```sh
+s3same some-repo-name --owner some-user --pro
 ```
-$ s3same some-repo-name --owner some-user --pro
-```
+
 will create an AWS IAM user unique to the repo (`s3same_travis__some-user__some-repo-name`), add that user to the `s3same_travis` AWS IAM group (creating the group if it doesn't exist) to give it the necessary permissions (defined by the `s3same_travis` policy, which will be created if it doesn't exist), generate an AWS key and secret for that user, use the public key for the given repo on Travis CI to encrypt the key and secret, and print out the YAML snippet to use for artifact uploading credentials.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 ## Prerequisities
 
-Make sure you have [`pip`](https://pip.pypa.io/en/stable/installing/) installed. `pip` is a package manager for Python packages. You can learn more by going to the [PyPI](https://pypi.org/) official website.
+Make sure you have `pip` installed, [check](https://pip.pypa.io/en/stable/installing/) if you need to install it. `pip` is a package manager for Python packages. You can learn more by going to the [PyPI](https://pypi.org/) official website.
+
+- You can run:
+
+  ```sh
+  sudo easy_install pip
+  ```
 
 A [`virtualenv`](https://virtualenv.pypa.io/en/latest/) environment is recommended since it keeps your Python projects organized by keeping installed packages in its own environment:
 
@@ -59,16 +65,6 @@ Default output format [None]: text
 ```
 
 **NOTE:** You may need the help of a Senior iOS dev or a member of the Systems team to generate an AWS Access Key ID and AWS Secret Access Key.
-
-- You may also need to install pip
-
-Run the command
-
-```sh
-sudo easy_install pip
-```
-
-to install.
 
 ## Installation
 

--- a/s3same/travis.py
+++ b/s3same/travis.py
@@ -1,6 +1,6 @@
 from base64 import b64encode
 from Crypto.PublicKey import RSA
-from Crypto.Cipher import PKCS1_v1_5
+from Crypto.Cipher import PKCS1_OAEP
 from Crypto.Util.py3compat import b
 import travispy
 
@@ -13,6 +13,6 @@ def _get_key(travis, repo_slug):
 
 def travis_encrypt(travis, repo_slug, string):
     return b64encode(
-            PKCS1_v1_5.new(
+            PKCS1_OAEP.new(
                 RSA.importKey(_get_key(travis, repo_slug))
                 ).encrypt(b(string)))

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
 from setuptools import setup
 
-try:
-    import pypandoc
-    long_description = pypandoc.convert('README.md', 'rst')
-except(IOError, ImportError):
-    long_description = open('README.md').read()
+with open("README.md", "r") as f:
+    long_description = f.read()
 
 setup(name='s3same',
       version='0.1',
@@ -20,6 +17,7 @@ setup(name='s3same',
       url='http://github.com/vokal/s3same',
       author='Vokal',
       author_email='pypi@vokal.io',
+      use_2to3=True,
       license='MIT',
       packages=['s3same'],
       install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as f:
     long_description = f.read()
 
 setup(name='s3same',
-      version='0.1',
+      version='0.2',
       description='Configure Travis-CI artifact uploading to S3',
       long_description=long_description,
       classifiers=[


### PR DESCRIPTION
Changed `PKCS1_v1_5` to `PKCS1_OAEP` as suggested in the package [website](https://pycryptodome.readthedocs.io/en/latest/src/cipher/pkcs1_v1_5.html). Added `use_2t03` to `setup.py` for support for Python2 and Python3. Suggested using `virtualenv` when installing `s3same`.
@adambain-vokal @Tuss4 @vokal-isaac 